### PR TITLE
Proposal to fix multiple default exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export default function rescue (callback: Function) {
   }
 }
 
-rescue.from = function rescuefrom (constructor: { new(...args: any[]): Error }, fn: Function) {
+export function rescueFrom (constructor: { new(...args: any[]): Error }, fn: Function) {
   return function errorhandler (err: Error, req: Request, res: Response, next: NextFunction) {
     if (!(err instanceof constructor)) {
       return next(err)
@@ -20,5 +20,3 @@ rescue.from = function rescuefrom (constructor: { new(...args: any[]): Error }, 
     fn(err, req, res, next)
   }
 }
-
-module.exports = rescue


### PR DESCRIPTION
As I stated [here](https://github.com/rwillians/express-rescue/commit/0ca459d1cfbe0285e853793d572467994192a348#commitcomment-33109389), the `from` function is messing up the namespace, and this is throwing a production error...

If we split the `from` function to a different export, things might work. It's a breaking change though