### PR TITLE
Make it easier to wrap multiple middlewares with rescue: rescue.all

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setting up node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install and build
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,42 @@
+name: Coverage Report
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**/*.ts'
+      - 'test/**/*.js'
+      - 'tsconfig.json'
+
+env:
+  NODE_VERSION: 18
+
+jobs:
+  coverage:
+    name: Report coverage to Coveralls
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+
+      - name: Setting up node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install and build
+        run: |
+          npm install
+          npm run build
+
+      - name: Run coverage
+        run: |
+          npm run coverage
+          npm run coverage:report
+
+      - name: Run coveralls
+        uses: coverallsapp/github-action@v1.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ app.get('/:id', rescue(async (req, res, next) => {
 }))
 
 /**
- * `rescue.all` insures thrown errors from every middleware in the array will be passed to `next` callback.
+ * `rescue.all` insures thrown errors coming from any middleware inside the array will be passed to `next` callback.
  */
 app.post('/login', rescue.all([
   validateLogin,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
-[![Coverage Status](https://coveralls.io/repos/github/rwillians/express-rescue/badge.svg?branch=master)](https://coveralls.io/github/rwillians/express-rescue?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/rwillians/express-rescue/badge.svg?branch=main)](https://coveralls.io/github/rwillians/express-rescue?branch=main)
 [![Build Status](https://travis-ci.org/rwillians/express-rescue.svg?branch=master)](https://travis-ci.org/rwillians/express-rescue)
 ![node-current](https://img.shields.io/node/v/express-rescue)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 [![Coverage Status](https://coveralls.io/repos/github/rwillians/express-rescue/badge.svg?branch=main)](https://coveralls.io/github/rwillians/express-rescue?branch=main)
-[![Build Status](https://travis-ci.org/rwillians/express-rescue.svg?branch=master)](https://travis-ci.org/rwillians/express-rescue)
+[![CI](https://github.com/rwillians/express-rescue/actions/workflows/ci_pr.yml/badge.svg)](https://github.com/rwillians/express-rescue/actions/workflows/ci_pr.yml)
 ![node-current](https://img.shields.io/node/v/express-rescue)
 
 [![NPM](https://nodei.co/npm/express-rescue.png)](https://npmjs.org/package/express-rescue)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 ![node-current](https://img.shields.io/node/v/express-rescue)
 ![Downloads](https://img.shields.io/npm/dy/express-rescue)
 
-[![NPM](https://nodei.co/npm/express-rescue.png)](https://npmjs.org/package/express-rescue)
-
 # Express Rescue
 
 This is a dependency-free wrapper (or sugar code layer if you will) for async middlewares which makes sure all async errors are passed to your stack of error handlers, allowing you to have a **cleaner and more readable code**.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/rwillians/express-rescue/badge.svg?branch=main)](https://coveralls.io/github/rwillians/express-rescue?branch=main)
 [![CI](https://github.com/rwillians/express-rescue/actions/workflows/ci_pr.yml/badge.svg)](https://github.com/rwillians/express-rescue/actions/workflows/ci_pr.yml)
 ![node-current](https://img.shields.io/node/v/express-rescue)
+![Downloads](https://img.shields.io/npm/dy/express-rescue)
 
 [![NPM](https://nodei.co/npm/express-rescue.png)](https://npmjs.org/package/express-rescue)
 

--- a/README.md
+++ b/README.md
@@ -65,17 +65,20 @@ Chears!
 ## Tests
 
 ```txt
-> express-rescue@1.1.26 test /Users/rwillians/Projects/express-rescue
-> mocha specs --require ./specs/spec-helper.js
+> mocha test/*.test.js --check-leaks --full-trace --use_strict --recursive
 
   const callable = rescue(async ([err,] req, res, next) => { })
     calls the last argument (next) with the thrown error
-      ✓ All arguments are been passed to the callback
-      ✓ Raises a TypeError if last argument is not a function
-      ✓ callable(req, res, next) - works for routes and middlewares
-      ✓ callable(err, req, res, next) - works for error handler middlewares
-      ✓ callable(foo, bar, baz, foobar, foobaz, errorHandler) - should work for basically anything, since you place an error handler as the last argument
+      ✔ All arguments are been passed to the callback
+      ✔ Raises a TypeError if last argument is not a function
+      ✔ callable(req, res, next) - works for routes and middlewares
+      ✔ callable(err, req, res, next) - works for error handler middlewares
+      ✔ callable(foo, bar, baz, foobar, foobaz, errorHandler) - should work for basically anything, since you place an error handler as the last argument
+
+  rescue.from(MyError, (err) => { })
+    ✔ handles the error when error is instance of given constructor
+    ✔ it call `next` function if error is not an instance of given constructor
 
 
-  5 passing (7ms)
+  7 passing (7ms)
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ app.get('/:id', rescue(async (req, res, next) => {
 }))
 
 /**
+ * `rescue.all` insures thrown errors from every middleware in the array will be passed to `next` callback.
+ */
+app.post('/login', rescue.all([
+  validateLogin,
+  loginController.login,
+]));
+
+/**
  * `rescue.from` allows you to handle a specific error which is helpful for
  * handling domain errors.
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-rescue",
-  "version": "1.1.32",
+  "version": "1.2.0",
   "description": "A wrapper for async functions which makes sure all async errors are passed to your errors handler",
   "license": "MIT",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Request, Response, NextFunction } from 'express'
 export { Request, Response, NextFunction }
 export declare type Callback = (...args: any[]) => Promise<void> | void
 export declare type ErrorConstructor = { new(...args: any[]): Error }
+
 export declare interface Rescue {
   (callback: Callback): Callback
   from (constructor: ErrorConstructor, callback: Callback): Callback


### PR DESCRIPTION
# PT-BR:
O Express suporta que passemos como segundo parâmetro de uma rota (router) um array contendo nossos middlewares, como no exemplo:
```
router.post('/', [
  validateToken,
  validateProductsIds,
  validadeIfProductsExists,
  orderController.create,
]);
```

Antigamente, se eu quisesse assegurar que todos os middlewares seriam corretamente protegidos pelo rescue, eu teria que adicionar `rescue(middleware)` a cada um deles.
```
router.post('/', [
  rescue(validateToken),
  rescue(validateProductsIds),
  rescue(validadeIfProductsExists),
  rescue(orderController.create),
]);
```

Então, eu criei o `rescue.all`, que é literalmente o `rescue` normal, mas aceita um array, e assegura que todos esses elementos sejam assegurados pelo `rescue`.
```
router.post('/', rescue.all([
  validateToken,
  validateProductsIds,
  validadeIfProductsExists,
  orderController.create,
]));
```

**AJUDA:** Agora estou em dúvidas, de como criar os testes para o `rescue.all`!
**OBSERVAÇÃO:** Eu testei o funcionamento do `rescue.all` em uma aplicação real, localmente, funcionou.

# EN-US:
Express supports passing as the second parameter of a route (router) an array containing our middlewares, as in the example:
```
router.post('/', [
  validateToken,
  validateProductsIds,
  validadeIfProductsExists,
  orderController.create,
]);
```

Previously, if I wanted to make sure that all middlewares were correctly protected by rescue, I would have to add `rescue(middleware)` to each of it.
```
router.post('/', [
  rescue(validateToken),
  rescue(validateProductsIds),
  rescue(validadeIfProductsExists),
  rescue(orderController.create),
]);
```

So I created `rescue.all`, which is literally normal `rescue`, but it accepts an array, and makes sure that all those elements are secured by `rescue`.
```
router.post('/', rescue.all([
  validateToken,
  validateProductsIds,
  validadeIfProductsExists,
  orderController.create,
]));
```

**HELP:** Now I am in doubt, how to create the tests for `rescue.all`!
**NOTE:** I have tested if `rescue.all` works in a real application, locally, worked.